### PR TITLE
Local TimeStamps and Support for version 1.2.0.4274 of MongoDB Official Driver

### DIFF
--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -208,6 +208,7 @@ namespace Elmah
 			{
 				var id = document["_id"].AsObjectId.ToString();
 				var error = BsonSerializer.Deserialize<Error>(document);
+			  error.Time = error.Time.ToLocalTime();
 				errorEntryList.Add(new ErrorLogEntry(this, id, error));
 			}
 

--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -211,7 +211,7 @@ namespace Elmah
 				errorEntryList.Add(new ErrorLogEntry(this, id, error));
 			}
 
-			return _collection.Count();
+			return (int) _collection.Count();
 		}
 
 		public static int GetCollectionLimit(IDictionary config)

--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -15,6 +15,11 @@ namespace Elmah
 			get { return instance; }
 		}
 
+    public override object Deserialize(BsonReader bsonReader, Type nominalType, Type actualType, IBsonSerializationOptions options)
+    {
+      return Deserialize(bsonReader, nominalType, options);
+    }
+
 		public override object Deserialize(
 			BsonReader bsonReader,
 			Type nominalType,


### PR DESCRIPTION
Since Mongo stores dates as UTC the times displayed in the Elmah error list were in UTC instead of local time. So when Errors are pulled out I added a line to convert the time back to local.

The other two changes are for this:

I just upgraded to version 2 of Mongo and downloaded the 1.2 version of the official driver. They made a couple of API changes that broke the Elmah logger. This pull request includes the two changes I had to make to be compatible with the new driver.

It looks like you were using NuGet to add the driver to the solution but just didn't check it into GitHub. The driver package has been updated on NuGet so you could use it again to update to the latest version if you decide to upgrade and incorporate these changes.

Thanks!
