### PR TITLE
Handles invalid BSON property names in NameValueCollectionSerializer

### DIFF
--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -30,7 +30,7 @@ namespace Elmah
 			bsonReader.ReadStartDocument();
 			while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
 			{
-				var name = bsonReader.ReadName();
+				var name = bsonReader.ReadName().Replace("__period__", ".");
 				var value = bsonReader.ReadString();
 				nvc.Add(name, value);
 			}
@@ -51,7 +51,7 @@ namespace Elmah
 			{
 				foreach (var key in nvc.AllKeys)
 				{
-					bsonWriter.WriteString(key, nvc[key]);
+					bsonWriter.WriteString(key.Replace(".", "__period__"), nvc[key]);
 				}
 			}
 			bsonWriter.WriteEndDocument();


### PR DESCRIPTION
. is in invalid character in the property name of a BSON object. This was discovered
when attempting to log an error via Elmah that had a cookie whose name had a
period in it. The period is replaced with placeholder text that is then replaced
upon deserialization.
