### PR TITLE
Fix $ char issue

### DIFF
--- a/src/Elmah.MongoDB/App_Readme/Elmah.txt
+++ b/src/Elmah.MongoDB/App_Readme/Elmah.txt
@@ -1,0 +1,15 @@
+A new HTTP handler has been configured in your application for consulting the
+error log and its feeds. It is reachable at elmah.axd under your application 
+root. If, for example, your application is deployed at http://www.example.com,
+the URL for ELMAH would be http://www.example.com/elmah.axd. You can, of
+course, change this path in your application's configuration file.
+
+ELMAH is also set up to be secure such that it can only be accessed locally.
+You can enable remote access but then it is paramount that you secure access
+to authorized users or/and roles only. This can be done using standard
+authorization rules and configuration already built into ASP.NET. For more
+information, see http://code.google.com/p/elmah/wiki/SecuringErrorLogPages on
+the project site.
+
+Please review the commented out authorization section under
+<location path="elmah.axd"> and make the appropriate changes.

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -34,25 +34,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah, Version=1.2.14318.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.corelibrary.1.2.1\lib\Elmah.dll</HintPath>
+    <Reference Include="Elmah">
+      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.3.1.4349, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.3.1\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.4\lib\net35\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.3.1.4349, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.3.1\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.4\lib\net35\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MongoErrorLog.cs" />
@@ -61,6 +57,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="App_Readme\Elmah.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -37,13 +37,11 @@
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.4.1.4490, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.4.1\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.5\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.4.1.4490, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.4.1\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.5\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -37,13 +37,13 @@
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\packages\mongocsharpdriver.1.4\lib\net35\MongoDB.Bson.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MongoDB.Bson, Version=1.4.1.4490, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\mongocsharpdriver.1.4.1\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\packages\mongocsharpdriver.1.4\lib\net35\MongoDB.Driver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MongoDB.Driver, Version=1.4.1.4490, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\mongocsharpdriver.1.4.1\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -15,6 +15,7 @@ namespace Elmah
 		private readonly string _collectionName;
 		private readonly int _maxDocuments;
 		private readonly int _maxSize;
+		private MongoInsertOptions _mongoInsertOptions;
 
 		private MongoCollection<BsonDocument> _collection;
 
@@ -128,6 +129,7 @@ namespace Elmah
 				}
 
 				_collection = database.GetCollection(_collectionName);
+				_mongoInsertOptions = new MongoInsertOptions { CheckElementNames = false };
 			}
 		}
 
@@ -163,7 +165,7 @@ namespace Elmah
 			var id = ObjectId.GenerateNewId();
 			document.Add("_id", id);
 
-			_collection.Insert(document);
+			_collection.Insert(document, _mongoInsertOptions);
 
 			return id.ToString();
 		}

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="elmah" version="1.2.2" />
   <package id="elmah.corelibrary" version="1.2.2" />
-  <package id="mongocsharpdriver" version="1.4" />
+  <package id="mongocsharpdriver" version="1.4.1" />
 </packages>

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="elmah" version="1.2.2" />
   <package id="elmah.corelibrary" version="1.2.2" />
-  <package id="mongocsharpdriver" version="1.4.1" />
+  <package id="mongocsharpdriver" version="1.5" targetFramework="net35" />
 </packages>

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="elmah" version="1.2.0.1" />
-  <package id="elmah.corelibrary" version="1.2.1" />
-  <package id="mongocsharpdriver" version="1.3.1" />
+  <package id="elmah" version="1.2.2" />
+  <package id="elmah.corelibrary" version="1.2.2" />
+  <package id="mongocsharpdriver" version="1.4" />
 </packages>


### PR DESCRIPTION
Issue: 
When using Elmah-MongoDB with WebApi + OData, query string has parameters like $top, $skip, etc it throws an exception $ are not allowed...
Discussion:
http://groups.google.com/group/mongodb-user/browse_thread/thread/e0f1719762997644
Fix:
Switch off checking element names when inserting documents, it would allow to have $ char in error description.

Update packages.
