### PR TITLE
Updated packages and made GetConnectionString method virtual

### DIFF
--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
+    <RestorePackages>false</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,17 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elmah, Version=1.2.14318.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\elmah.corelibrary.1.2.1\lib\Elmah.dll</HintPath>
+    <Reference Include="Elmah">
+      <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.3.1.4349, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.3.1\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\mongocsharpdriver.1.4.2\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.3.1.4349, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.3.1\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\mongocsharpdriver.1.4.2\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -61,6 +58,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="App_Readme\Elmah.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -227,7 +227,7 @@ namespace Elmah
 			return int.TryParse((string)config["maxSize"], out result) ? result : DefaultMaxSize;
 		}
 
-		public static string GetConnectionString(IDictionary config)
+		public virtual string GetConnectionString(IDictionary config)
 		{
 #if !NET_1_1 && !NET_1_0
 			//

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="elmah" version="1.2.0.1" />
-  <package id="elmah.corelibrary" version="1.2.1" />
-  <package id="mongocsharpdriver" version="1.3.1" />
+<packages>  
+  <package id="elmah" version="1.2.2" />  
+  <package id="elmah.corelibrary" version="1.2.2" />  
+  <package id="mongocsharpdriver" version="1.4.2" />
 </packages>


### PR DESCRIPTION
I updated the packages, plus I made the GetConnectionString method virtual.

This is useful for when I want to resolve the connectionstring in another way. For example, I couldn't use this package when deploying to AppHarbor as is. I had to make a custom implementation  which overrides the GetConnectionString method and returns a value from the appsettings section.

I also had to change the GetConnectionString method to be non-static, so this _might_ impact other consumers, although I'm pretty sure hardly anybody is using that method anyways. It's also an option to have both methods available for backwards compatibility if this would be an issue.

Regards
Jef
