### PR TITLE
Guard against error if the key is null

### DIFF
--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -51,6 +51,11 @@ namespace Elmah
 			{
 				foreach (var key in nvc.AllKeys)
 				{
+					if (string.IsNullOrWhiteSpace(key))
+                    			{
+                        			continue;
+                    			}
+
 					bsonWriter.WriteString(key.Replace(".", "__period__"), nvc[key]);
 				}
 			}


### PR DESCRIPTION
If the query string on the request is malformed, something like "http://yoursite.com?key", the QueryString NameValueCollection will have a null key. This is causing an error to be thrown when serializing the Elmah Error for MongoDB.
