### PR TITLE
Maintain a null key by doing a substitution

### DIFF
--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -30,10 +30,9 @@ namespace Elmah
 			bsonReader.ReadStartDocument();
 			while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
 			{
-				var name = bsonReader.ReadName();
-				var originalName = (name == "__null__") ? null : name.Replace("__period__", ".").Replace("__dollarsign__", "$");
+				var name = bsonReader.ReadName().Replace("__period__", ".");
 				var value = bsonReader.ReadString();
-				nvc.Add(originalName, value);
+				nvc.Add(name, value);
 			}
 			bsonReader.ReadEndDocument();
 			return nvc;
@@ -52,14 +51,12 @@ namespace Elmah
 			{
 				foreach (var key in nvc.AllKeys)
 				{
-					var legalKey = key ?? "__null__";
-					legalKey = legalKey.Replace(".", "__period__");
-					if (legalKey.StartsWith("$"))
-					{
-						legalKey = "__dollarsign__" + legalKey.Substring(1);
-					}
+					if (string.IsNullOrWhiteSpace(key))
+                    			{
+                        			continue;
+                    			}
 
-					bsonWriter.WriteString(legalKey, nvc[key]);
+					bsonWriter.WriteString(key.Replace(".", "__period__"), nvc[key]);
 				}
 			}
 			bsonWriter.WriteEndDocument();


### PR DESCRIPTION
Maintain a null key by doing a substitution before it's serialized for
MongoDB. Also, prevent issues with the illegal starting character: "$".

Sorry about the commit-revert-commit. I didn't have the line endings setup properly at first.
