### PR TITLE
Updating MongoDB package dependency

### DIFF
--- a/pkg/nuget/nuspec/Elmah.MongoDB.nuspec
+++ b/pkg/nuget/nuspec/Elmah.MongoDB.nuspec
@@ -15,7 +15,7 @@
     <tags>mongodb elmah error logging unhandled exception</tags>
     <dependencies>
       <dependency id="elmah" version="1.2.2" />
-      <dependency id="mongocsharpdriver" version="1.5" />
+      <dependency id="mongocsharpdriver" version="1.7" />
     </dependencies>
   </metadata>
 </package>

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
-    <RestorePackages>false</RestorePackages>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,11 +37,13 @@
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\packages\mongocsharpdriver.1.5\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\packages\mongocsharpdriver.1.5\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Driver.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -51,7 +51,7 @@ namespace Elmah
 			{
 				foreach (var key in nvc.AllKeys)
 				{
-					if (string.IsNullOrWhiteSpace(key))
+					if (string.IsNullOrEmpty(key))
                     			{
                         			continue;
                     			}

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>  
+<packages>
   <package id="elmah" version="1.2.2" />
   <package id="elmah.corelibrary" version="1.2.2" />
-  <package id="mongocsharpdriver" version="1.5" targetFramework="net35" />
+  <package id="mongocsharpdriver" version="1.7" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
We are trying to use your Nuget package, but have found since the 1.7 mongo driver release that it is throwing a MissingMethodException--probably since return types have changed in this release. I've updated the dependency.
