### PR TITLE
Update for MongoDB driver 2.10.4 and add Azure Cosmos support

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -24,3 +24,16 @@ Here is an example configuration:
     <connectionStrings>
       <add name="elmah-mongodb" connectionString="mongodb://localhost/elmah?w=0"/>
     </connectionStrings>
+
+## Azure Cosmos Support
+Azure Cosmos is not 100% API compatible with MongoDB and as such requires some modifications to the behavior of this library in order to be compatible.
+
+These issues are known as of 6/14/2020:
+- Capped collections are not supported
+- $natural is not supported for sorting
+
+In order to work around these issues, use the following additional attributes to disable capped collection on collection creation and use the primary key for sorting:
+
+    <elmah>
+      <errorLog type="Elmah.MongoErrorLog, Elmah.MongoDB" connectionStringName="elmah-mongodb" maxSize="10485760" maxDocuments="10000" sortKey="_id" useCappedCollection="false"/>
+    </elmah>

--- a/src/Elmah-MongoDB.sln
+++ b/src/Elmah-MongoDB.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elmah.MongoDB", "Elmah.MongoDB\Elmah.MongoDB.csproj", "{41AFEE84-1EE9-4457-917A-52632B55A1BA}"
-EndProject
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{8341DC55-5656-478A-B15F-CD3CC0C087C0}"
 	ProjectSection(SolutionItems) = preProject
 		..\pkg\nuget\nuspec\Elmah.MongoDB.nuspec = ..\pkg\nuget\nuspec\Elmah.MongoDB.nuspec
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{F970C7
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elmah.MongoDB", "Elmah.MongoDB\Elmah.MongoDB.csproj", "{41AFEE84-1EE9-4457-917A-52632B55A1BA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elmah.MongoDB.Sample", "Elmah.MongoDB.Sample\Elmah.MongoDB.Sample.csproj", "{B0812E20-6414-4648-A4F6-F7376FA7939C}"
 EndProject

--- a/src/Elmah.MongoDB.Sample/Elmah.MongoDB.Sample.csproj
+++ b/src/Elmah.MongoDB.Sample/Elmah.MongoDB.Sample.csproj
@@ -22,6 +22,12 @@
     <IISExpressUseClassicPipelineMode />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Elmah.MongoDB.Sample/Elmah.MongoDB.Sample.csproj
+++ b/src/Elmah.MongoDB.Sample/Elmah.MongoDB.Sample.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Elmah.MongoDB.Sample</RootNamespace>
     <AssemblyName>Elmah.MongoDB.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -28,6 +28,9 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <TargetFrameworkProfile />
+    <Use64BitIISExpress />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -64,21 +67,19 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20715.0\lib\net40\System.Web.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Abstractions" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
@@ -121,6 +122,7 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\WebGrease.1.3.0\lib\WebGrease.dll</HintPath>

--- a/src/Elmah.MongoDB.Sample/Web.config
+++ b/src/Elmah.MongoDB.Sample/Web.config
@@ -29,9 +29,17 @@
     <add key="elmah.mvc.allowedRoles" value="*" />
     <add key="elmah.mvc.route" value="elmah" />
   </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.5.2" />
+      </system.Web>
+  -->
   <system.web>
     <httpRuntime targetFramework="4.5" />
-    <compilation debug="true" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.6" />
     <authentication mode="Forms">
       <forms loginUrl="~/Account/Login" timeout="2880" />
     </authentication>
@@ -85,6 +93,22 @@
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.3.0.0" newVersion="1.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="DnsClient" publicKeyToken="4574bb5573c51424" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.3.2.0" newVersion="1.3.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="SharpCompress" publicKeyToken="afb0a02973931d96" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.25.1.0" newVersion="0.25.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Elmah.MongoDB.Sample/Web.config
+++ b/src/Elmah.MongoDB.Sample/Web.config
@@ -15,7 +15,7 @@
     </sectionGroup>
   </configSections>
   <connectionStrings>
-    <add name="elmah-mongodb" connectionString="mongodb://localhost/elmah?w=0" />
+    <add name="elmah-mongodb" connectionString="mongodb://remote:7CrazyIdea@mongo1.beta.cityspark.com:27017/elmah?w=0" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="2.0.0.0" />

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,11 +10,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Elmah</RootNamespace>
     <AssemblyName>Elmah.MongoDB</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,22 +38,49 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Crc32C.NET, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Crc32C.NET.1.0.5.0\lib\net20\Crc32C.NET.dll</HintPath>
+    </Reference>
+    <Reference Include="DnsClient, Version=1.3.2.0, Culture=neutral, PublicKeyToken=4574bb5573c51424, processorArchitecture=MSIL">
+      <HintPath>..\packages\DnsClient.1.3.2\lib\net45\DnsClient.dll</HintPath>
+    </Reference>
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson">
-      <HintPath>..\packages\MongoDB.Bson.2.0.0\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.10.4\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver">
-      <HintPath>..\packages\MongoDB.Driver.2.0.0\lib\net45\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.2.10.4\lib\net452\MongoDB.Driver.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver.Core">
-      <HintPath>..\packages\MongoDB.Driver.Core.2.0.0\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+    <Reference Include="MongoDB.Driver.Core, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.10.4\lib\net452\MongoDB.Driver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Libmongocrypt, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Libmongocrypt.1.0.0\lib\net452\MongoDB.Libmongocrypt.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpCompress, Version=0.25.1.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpCompress.0.25.1\lib\net46\SharpCompress.dll</HintPath>
+    </Reference>
+    <Reference Include="Snappy.NET, Version=1.1.1.8, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Snappy.NET.1.1.1.8\lib\net45\Snappy.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ErrorModel.cs" />
@@ -60,6 +89,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -67,6 +97,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="..\packages\MongoDB.Libmongocrypt.1.0.0\build\MongoDB.Libmongocrypt.targets" Condition="Exists('..\packages\MongoDB.Libmongocrypt.1.0.0\build\MongoDB.Libmongocrypt.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MongoDB.Libmongocrypt.1.0.0\build\MongoDB.Libmongocrypt.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MongoDB.Libmongocrypt.1.0.0\build\MongoDB.Libmongocrypt.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Elmah.MongoDB/Elmah.MongoDB.csproj
+++ b/src/Elmah.MongoDB/Elmah.MongoDB.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Elmah</RootNamespace>
     <AssemblyName>Elmah.MongoDB</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,18 +33,20 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elmah">
       <HintPath>..\packages\elmah.corelibrary.1.2.2\lib\Elmah.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson">
+      <HintPath>..\packages\MongoDB.Bson.2.0.0\lib\net45\MongoDB.Bson.dll</HintPath>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.7.0.4714, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\mongocsharpdriver.1.7\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver">
+      <HintPath>..\packages\MongoDB.Driver.2.0.0\lib\net45\MongoDB.Driver.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core">
+      <HintPath>..\packages\MongoDB.Driver.Core.2.0.0\lib\net45\MongoDB.Driver.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -51,6 +54,7 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ErrorModel.cs" />
     <Compile Include="MongoErrorLog.cs" />
     <Compile Include="NameValueCollectionSerializer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Elmah.MongoDB/ErrorModel.cs
+++ b/src/Elmah.MongoDB/ErrorModel.cs
@@ -1,0 +1,16 @@
+﻿using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elmah
+{
+    public class ErrorModel
+    {
+        public ObjectId _id { get; set; }
+
+        public Error Error { get; set; }
+    }
+}

--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -63,7 +63,7 @@ namespace Elmah
 
 			ApplicationName = appName;
 
-			_collectionName = appName.Length > 0 ? "Elmah-" + appName : "Elmah";
+			_collectionName = appName.Length > 0 ? "Elmah2-" + appName : "Elmah";
 			_maxDocuments = GetCollectionLimit(config);
 			_maxSize = GetCollectionSize(config);
 

--- a/src/Elmah.MongoDB/MongoErrorLog.cs
+++ b/src/Elmah.MongoDB/MongoErrorLog.cs
@@ -5,19 +5,20 @@ using System.Configuration;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
-using MongoDB.Driver.Builders;
-
+using System.Threading.Tasks;
+using System.Linq;
+using MongoDB.Bson.Serialization.Serializers;
 namespace Elmah
 {
 	public class MongoErrorLog : ErrorLog
 	{
 		private readonly string _connectionString;
 		private readonly string _collectionName;
-		private readonly int _maxDocuments;
-		private readonly int _maxSize;
-		private MongoInsertOptions _mongoInsertOptions;
+		private readonly long _maxDocuments;
+		private readonly long _maxSize;
+		//private MongoInsertOptions _mongoInsertOptions;
 
-		private MongoCollection<BsonDocument> _collection;
+        private IMongoCollection<ErrorModel> _collection;
 
 		private const int MaxAppNameLength = 60;
 		private const int DefaultMaxDocuments = int.MaxValue;
@@ -89,7 +90,7 @@ namespace Elmah
 
 		static MongoErrorLog()
 		{
-			BsonSerializer.RegisterSerializer(typeof(NameValueCollection), NameValueCollectionSerializer.Instance);
+            BsonSerializer.RegisterSerializer(typeof(NameValueCollection), new NameValueCollectionSerializer());
 			BsonClassMap.RegisterClassMap<Error>(cm =>
 			{
 				cm.MapProperty(c => c.ApplicationName);
@@ -116,23 +117,27 @@ namespace Elmah
 			{
 				var mongoUrl = MongoUrl.Create(_connectionString);
 				var mongoClient = new MongoClient(mongoUrl);
-				var server = mongoClient.GetServer();
-				var database = server.GetDatabase(mongoUrl.DatabaseName);
-				if (!database.CollectionExists(_collectionName))
+				//var server = mongoClient.GetServer();
+
+                var database = mongoClient.GetDatabase(mongoUrl.DatabaseName);
+                //var filter = new Filter(new BsonDocument("name", _collectionName));
+                var findThisOne = new ListCollectionsOptions();
+                findThisOne.Filter = Builders<BsonDocument>.Filter.Eq("name", _collectionName);
+                var cursor = database.ListCollectionsAsync(findThisOne).Result;
+                var list = cursor.ToListAsync().GetAwaiter().GetResult();
+                var allCollections = list.Select(c => c["name"].AsString).OrderBy(n => n).ToList();
+                if (!allCollections.Contains(_collectionName))
 				{
-					var options = CollectionOptions
-						.SetCapped(true)
-						.SetAutoIndexId(true)
-						.SetMaxSize(_maxSize);
+					var options = new CreateCollectionOptions();
+                    options.Capped = true;
+                    options.AutoIndexId = true;
+                    options.MaxSize = _maxSize;
 
-					if (_maxDocuments != int.MaxValue)
-						options.SetMaxDocuments(_maxDocuments);
-
-					database.CreateCollection(_collectionName, options);
+                    database.CreateCollectionAsync(_collectionName, options).GetAwaiter().GetResult();
 				}
 
-				_collection = database.GetCollection(_collectionName);
-				_mongoInsertOptions = new MongoInsertOptions { CheckElementNames = false };
+                _collection = database.GetCollection<ErrorModel>(_collectionName);
+				//_mongoInsertOptions = new MongoInsertOptions { CheckElementNames = false };
 			}
 		}
 
@@ -163,12 +168,13 @@ namespace Elmah
 				throw new ArgumentNullException("error");
 
 			error.ApplicationName = ApplicationName;
-			var document = error.ToBsonDocument();
+            var toStore = new ErrorModel();
+            
 
 			var id = ObjectId.GenerateNewId();
-			document.Add("_id", id);
-
-			_collection.Insert(document, _mongoInsertOptions);
+			toStore._id = id;
+            toStore.Error = error;
+			_collection.InsertOneAsync(toStore).GetAwaiter().GetResult();
 
 			return id.ToString();
 		}
@@ -184,14 +190,12 @@ namespace Elmah
 			if (id == null) throw new ArgumentNullException("id");
 			if (id.Length == 0) throw new ArgumentException(null, "id");
 
-			var document = _collection.FindOneById(new ObjectId(id));
+            var document = _collection.Find<ErrorModel>(x=> x._id == ObjectId.Parse(id)).SingleOrDefaultAsync().Result;
 
 			if (document == null)
 				return null;
 
-			var error = BsonSerializer.Deserialize<Error>(document);
-
-			return new ErrorLogEntry(this, id, error);
+			return new ErrorLogEntry(this, id, document.Error);
 		}
 
 		/// <summary>
@@ -207,17 +211,18 @@ namespace Elmah
 			if (pageIndex < 0) throw new ArgumentOutOfRangeException("pageIndex", pageIndex, null);
 			if (pageSize < 0) throw new ArgumentOutOfRangeException("pageSize", pageSize, null);
 
-			var documents = _collection.FindAll().SetSortOrder(SortBy.Descending("$natural")).SetSkip(pageIndex * pageSize).SetLimit(pageSize);
+			var documents = _collection.Find(new BsonDocument()).Sort("{$natural: -1}").Skip(pageIndex * pageSize)
+                .Limit(pageSize).ToListAsync()
+                .GetAwaiter().GetResult();//.SetSortOrder(SortBy.Descending("$natural")).SetSkip(pageIndex * pageSize).SetLimit(pageSize);
 
 			foreach (var document in documents)
 			{
-				var id = document["_id"].AsObjectId.ToString();
-				var error = BsonSerializer.Deserialize<Error>(document);
-			  error.Time = error.Time.ToLocalTime();
-				errorEntryList.Add(new ErrorLogEntry(this, id, error));
+                var error = document.Error;
+			    error.Time = error.Time.ToLocalTime();
+				errorEntryList.Add(new ErrorLogEntry(this, document._id.ToString(), error));
 			}
 
-			return (int) _collection.Count();
+			return Convert.ToInt32(_collection.CountAsync(new BsonDocument()).Result);
 		}
 
 		public static int GetCollectionLimit(IDictionary config)
@@ -234,7 +239,6 @@ namespace Elmah
 
 		public virtual string GetConnectionString(IDictionary config)
 		{
-#if !NET_1_1 && !NET_1_0
 			//
 			// First look for a connection string name that can be 
 			// subsequently indexed into the <connectionStrings> section of 
@@ -252,7 +256,7 @@ namespace Elmah
 
 				return settings.ConnectionString ?? string.Empty;
 			}
-#endif
+
 
 			//
 			// Connection string name not found so see if a connection 

--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -3,6 +3,7 @@ using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 using System;
+using System.Linq;
 using System.Collections.Specialized;
 
 namespace Elmah
@@ -15,12 +16,12 @@ namespace Elmah
             BsonDocument doc = new BsonDocument();
             if (value != null)
             {
-                foreach (var key in value.AllKeys)
+                foreach (var key in value.AllKeys.Distinct())
                 {
-                    foreach (var val in value.GetValues(key))
-                    {
+                    var val = value.GetValues(key).FirstOrDefault();
+                    if(val != null)
                         doc.Add(key.Replace('.','|'), val);
-                    }
+                    
                 }
             }
 

--- a/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
+++ b/src/Elmah.MongoDB/NameValueCollectionSerializer.cs
@@ -7,76 +7,108 @@ using System.Collections.Specialized;
 
 namespace Elmah
 {
-	public class NameValueCollectionSerializer : BsonBaseSerializer
-	{
-		private static readonly NameValueCollectionSerializer instance = new NameValueCollectionSerializer();
+    public class NameValueCollectionSerializer : SerializerBase<NameValueCollection>
+    {
+        BsonDocumentSerializer documentserializer = new BsonDocumentSerializer();
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, NameValueCollection value)
+        {
+            BsonDocument doc = new BsonDocument();
+            if (value != null)
+            {
+                foreach (var key in value.AllKeys)
+                {
+                    foreach (var val in value.GetValues(key))
+                    {
+                        doc.Add(key.Replace('.','|'), val);
+                    }
+                }
+            }
 
-		public static NameValueCollectionSerializer Instance
-		{
-			get { return instance; }
-		}
+            documentserializer.Serialize(context, doc);
+        }
 
-		public override object Deserialize(BsonReader bsonReader, Type nominalType, Type actualType, IBsonSerializationOptions options)
-		{
-			return Deserialize(bsonReader, nominalType, options);
-		}
+        public override NameValueCollection Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            BsonDocument doc = documentserializer.Deserialize(context);
+            var nvc = new NameValueCollection();
+            foreach (var prop in doc)
+            {
+                nvc.Add(prop.Name.Replace('|','.'), prop.Value.ToString());
+            }
 
-		public override object Deserialize(
-			BsonReader bsonReader,
-			Type nominalType,
-			IBsonSerializationOptions options
-			)
-		{
-			var bsonType = bsonReader.GetCurrentBsonType();
-			if (bsonType == BsonType.Null)
-			{
-				bsonReader.ReadNull();
-				return null;
-			}
+            return nvc;
+        }
+    }
+    //public class NameValueCollectionSerializer : BsonBaseSerializer
+    //{
+    //    private static readonly NameValueCollectionSerializer instance = new NameValueCollectionSerializer();
 
-			var nvc = new NameValueCollection();
+    //    public static NameValueCollectionSerializer Instance
+    //    {
+    //        get { return instance; }
+    //    }
 
-			bsonReader.ReadStartArray();
-			while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
-			{
-				bsonReader.ReadStartArray();
-				var key = (string)StringSerializer.Instance.Deserialize(bsonReader, typeof(string), options);
-				var val = (string)StringSerializer.Instance.Deserialize(bsonReader, typeof(string), options);
-				bsonReader.ReadEndArray();
-				nvc.Add(key, val);
-			}
-			bsonReader.ReadEndArray();
+    //    public override object Deserialize(BsonReader bsonReader, Type nominalType, Type actualType, IBsonSerializationOptions options)
+    //    {
+    //        return Deserialize(bsonReader, nominalType, options);
+    //    }
 
-			return nvc;
-		}
+    //    public override object Deserialize(
+    //        BsonReader bsonReader,
+    //        Type nominalType,
+    //        IBsonSerializationOptions options
+    //        )
+    //    {
+    //        var bsonType = bsonReader.GetCurrentBsonType();
+    //        if (bsonType == BsonType.Null)
+    //        {
+    //            bsonReader.ReadNull();
+    //            return null;
+    //        }
 
-		public override void Serialize(
-			BsonWriter bsonWriter,
-			Type nominalType,
-			object value,
-			IBsonSerializationOptions options
-			)
-		{
-			if (value == null)
-			{
-				bsonWriter.WriteNull();
-				return;
-			}
+    //        var nvc = new NameValueCollection();
 
-			var nvc = (NameValueCollection)value;
+    //        bsonReader.ReadStartArray();
+    //        while (bsonReader.ReadBsonType() != BsonType.EndOfDocument)
+    //        {
+    //            bsonReader.ReadStartArray();
+    //            var key = (string)StringSerializer.Instance.Deserialize(bsonReader, typeof(string), options);
+    //            var val = (string)StringSerializer.Instance.Deserialize(bsonReader, typeof(string), options);
+    //            bsonReader.ReadEndArray();
+    //            nvc.Add(key, val);
+    //        }
+    //        bsonReader.ReadEndArray();
 
-			bsonWriter.WriteStartArray();
-			foreach (var key in nvc.AllKeys)
-			{
-				foreach (var val in nvc.GetValues(key))
-				{
-					bsonWriter.WriteStartArray();
-					StringSerializer.Instance.Serialize(bsonWriter, typeof(string), key, options);
-					StringSerializer.Instance.Serialize(bsonWriter, typeof(string), val, options);
-					bsonWriter.WriteEndArray();
-				}
-			}
-			bsonWriter.WriteEndArray();
-		}
-	}
+    //        return nvc;
+    //    }
+
+    //    public override void Serialize(
+    //        BsonWriter bsonWriter,
+    //        Type nominalType,
+    //        object value,
+    //        IBsonSerializationOptions options
+    //        )
+    //    {
+    //        if (value == null)
+    //        {
+    //            bsonWriter.WriteNull();
+    //            return;
+    //        }
+
+    //        var nvc = (NameValueCollection)value;
+
+    //        bsonWriter.WriteStartArray();
+    //        foreach (var key in nvc.AllKeys)
+    //        {
+    //            foreach (var val in nvc.GetValues(key))
+    //            {
+    //                bsonWriter.WriteStartArray();
+    //                StringSerializer.Instance.Serialize(bsonWriter, typeof(string), key, options);
+    //                StringSerializer.Instance.Serialize(bsonWriter, typeof(string), val, options);
+    //                bsonWriter.WriteEndArray();
+    //            }
+    //        }
+    //        bsonWriter.WriteEndArray();
+    //    }
+    //}
 }

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -1,8 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Crc32C.NET" version="1.0.5.0" targetFramework="net452" />
+  <package id="DnsClient" version="1.3.2" targetFramework="net46" />
   <package id="elmah" version="1.2.2" />
   <package id="elmah.corelibrary" version="1.2.2" />
-  <package id="MongoDB.Bson" version="2.0.0" targetFramework="net45" />
-  <package id="MongoDB.Driver" version="2.0.0" targetFramework="net45" />
-  <package id="MongoDB.Driver.Core" version="2.0.0" targetFramework="net45" />
+  <package id="MongoDB.Bson" version="2.10.4" targetFramework="net452" />
+  <package id="MongoDB.Driver" version="2.10.4" targetFramework="net452" />
+  <package id="MongoDB.Driver.Core" version="2.10.4" targetFramework="net452" />
+  <package id="MongoDB.Libmongocrypt" version="1.0.0" targetFramework="net452" />
+  <package id="SharpCompress" version="0.25.1" targetFramework="net46" />
+  <package id="Snappy.NET" version="1.1.1.8" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net46" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net46" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net46" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/src/Elmah.MongoDB/packages.config
+++ b/src/Elmah.MongoDB/packages.config
@@ -2,5 +2,7 @@
 <packages>
   <package id="elmah" version="1.2.2" />
   <package id="elmah.corelibrary" version="1.2.2" />
-  <package id="mongocsharpdriver" version="1.7" targetFramework="net35" />
+  <package id="MongoDB.Bson" version="2.0.0" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.0.0" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This closes #15 by providing a current (as of 2020) MongoDB driver reference and adds additional configuration parameters (and documentation) for supporting collections in Azure Cosmos running under MongoDB compatibility.